### PR TITLE
swapped MOSI and MISO @ AtMega

### DIFF
--- a/doc/source/tw_spi/index.rst
+++ b/doc/source/tw_spi/index.rst
@@ -22,12 +22,12 @@ ATTiny - SPI master
    * - PB0
      - Digital Input (DI)
      - 50
-     - MOSI (Master Out/Slave In)
+     - MISO (Master In/Slave Out)
 
    * - PB1
      - Digital Output (DO)
      - 51
-     - MISO (Master In/Slave Out)
+     - MOSI (Master Out/Slave In)
 
    * - PB2
      - Clock


### PR DESCRIPTION
I have fixed a typo I made when publishing the documentation before, I have accidentally swapped the MISO/MOSI pins at the AtMega 2560 Pinout